### PR TITLE
chore: gitignore更新とMakefileサーバー管理コマンド追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -96,3 +96,6 @@ coverage.xml
 /frontend/src/app/fonts/
 /frontend/src/app/favicon.ico
 /frontend/README.md
+
+# Serena (MCP code assistant)
+.serena/

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # 🌙 Nocturne - PoC用 Makefile
 # Make commands for development and quality assurance
 
-.PHONY: help setup dev-backend dev-frontend dev quality test clean install-deps init-db poc ci ci-backend ci-frontend ci-integration
+.PHONY: help setup dev-backend dev-frontend dev quality test clean install-deps init-db poc ci ci-backend ci-frontend ci-integration stop restart
 
 # Default target
 help: ## Show this help message
@@ -112,6 +112,20 @@ reset-db: ## 🔄 Reset database (delete and reinitialize)
 	rm -f backend/database.db
 	@$(MAKE) init-db
 	@echo "✅ Database reset complete"
+
+# Server Management
+stop: ## 🛑 Stop all running servers (kill processes on ports 3000 and 8000)
+	@echo "🛑 Stopping servers..."
+	@echo "Checking port 8000 (backend)..."
+	@lsof -ti:8000 | xargs kill -9 2>/dev/null || echo "✓ Port 8000 is free"
+	@echo "Checking port 8001 (CI backend)..."
+	@lsof -ti:8001 | xargs kill -9 2>/dev/null || echo "✓ Port 8001 is free"
+	@echo "Checking port 3000 (frontend)..."
+	@lsof -ti:3000 | xargs kill -9 2>/dev/null || echo "✓ Port 3000 is free"
+	@echo "✅ All servers stopped"
+
+restart: stop dev ## 🔄 Restart all development servers
+	@echo "✅ Servers restarted"
 
 # Cleanup
 clean: ## 🧹 Clean build artifacts and temp files

--- a/frontend/next-env.d.ts
+++ b/frontend/next-env.d.ts
@@ -1,5 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
+/// <reference path="./.next/types/routes.d.ts" />
 
 // NOTE: This file should not be edited
-// see https://nextjs.org/docs/app/building-your-application/configuring/typescript for more information.
+// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,6 +1,10 @@
 {
   "compilerOptions": {
-    "lib": ["dom", "dom.iterable", "esnext"],
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,
@@ -18,9 +22,19 @@
       }
     ],
     "paths": {
-      "@/*": ["./src/*"]
-    }
+      "@/*": [
+        "./src/*"
+      ]
+    },
+    "target": "ES2017"
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
-  "exclude": ["node_modules"]
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
 }


### PR DESCRIPTION
## 📋 概要
開発環境の利便性向上のため、gitignore設定の更新とサーバー管理コマンドを追加

## 🔄 変更内容
### gitignore更新
- **`.serena/`** をgitignoreに追加
  - Serena（MCP code assistant）の個人設定・メモリファイル
  - チーム開発では不要な個人情報のため除外

### Makefileサーバー管理コマンド追加  
- **`make stop`** - 全開発サーバー停止
  - ポート8000（backend）、8001（CI backend）、3000（frontend）
  - lsofとkillによる強制終了
- **`make restart`** - サーバー再起動（stop + dev）

### Next.js 15自動更新
- **next-env.d.ts**: routes型定義とドキュメントURL更新
- **tsconfig.json**: フォーマット整理とtarget設定追加

## ✅ 利点
- **ポート競合解決**: make stopで簡単にプロセス停止
- **開発効率向上**: サーバー再起動が make restart 一発で完了
- **クリーンな環境**: .serena個人設定がリポジトリに混入しない

🤖 Generated with [Claude Code](https://claude.ai/code)